### PR TITLE
Display supplier name not organisation name regression changes

### DIFF
--- a/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/SolutionsList.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/SolutionsList.cs
@@ -73,14 +73,14 @@ namespace NHSDPublicBrowseAcceptanceTests.Actions.Pages
             return true;
         }
 
-        public int GetSolutionOrganisationNameCount()
+        public int GetSolutionSupplierNameCount()
         {
-            return driver.FindElements(pages.SolutionsList.SolutionOrganisationName).Count();
+            return driver.FindElements(pages.SolutionsList.SolutionSupplierName).Where(s => s.Text.Length > 0).Count();
         }
 
         public int GetSolutionNameCount()
         {
-            return driver.FindElements(pages.SolutionsList.SolutionName).Count();
+            return driver.FindElements(pages.SolutionsList.SolutionName).Where(s => s.Text.Length > 0).Count();
         }
 
         /// <summary>

--- a/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/ViewASolution.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/ViewASolution.cs
@@ -26,7 +26,7 @@ namespace NHSDPublicBrowseAcceptanceTests.Actions.Pages
 
         public string GetSupplierName()
         {
-            return driver.FindElement(pages.ViewSingleSolution.SolutionOrganisationName).Text;
+            return driver.FindElement(pages.ViewSingleSolution.SolutionSupplierName).Text;
         }
 
         public string GetSolutionName()

--- a/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/SolutionsList.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/SolutionsList.cs
@@ -7,7 +7,7 @@ namespace NHSDPublicBrowseAcceptanceTests.Objects.Pages
     {
         public By Solutions => CustomBy.DataTestId("solution-card");
         public By SolutionName => CustomBy.DataTestId("solution-card-name");
-        public By SolutionOrganisationName => CustomBy.DataTestId("solution-card-organisation");
+        public By SolutionSupplierName => CustomBy.DataTestId("solution-card-supplier");
         public By SolutionSummary => CustomBy.DataTestId("solution-card-summary");
         public By SolutionCapabilityList => CustomBy.DataTestId("capability-list");
         public By SolutionCapabilityName => CustomBy.DataTestId("capability-list-item");

--- a/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/ViewSingleSolution.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/ViewSingleSolution.cs
@@ -6,7 +6,7 @@ namespace NHSDPublicBrowseAcceptanceTests.Objects.Pages
     public sealed class ViewSingleSolution
     {
         public By SolutionId => CustomBy.DataTestId("view-solution-page-solution-id");
-        public By SolutionOrganisationName => CustomBy.DataTestId("view-solution-page-organisation-name");
+        public By SolutionSupplierName => CustomBy.DataTestId("view-solution-page-supplier-name");
         public By SolutionName => CustomBy.DataTestId("view-solution-page-solution-name");
         public By SolutionSummary => CustomBy.DataTestId("view-question-data-text-summary");
         public By SolutionCapabilities => CustomBy.DataTestId("view-solution-capabilities", "li");

--- a/src/NHSDPublicBrowseAcceptanceTestsSpecflow/Features/Solutions/ViewSolutionsList.feature
+++ b/src/NHSDPublicBrowseAcceptanceTestsSpecflow/Features/Solutions/ViewSolutionsList.feature
@@ -7,7 +7,7 @@ Scenario: List of Solution Cards
 	Given that a User has chosen to view a list of all Solutions
 	When Solutions are presented
 	Then there is a Card for each Solution
-	And the Card contains the Organisation Name
+	And the Card contains the Supplier Name
 	And the Solution Name
 	And the Solution Summary Description
 	And the names of the Capabilities provided by the Solution

--- a/src/NHSDPublicBrowseAcceptanceTestsSpecflow/Steps/BrowseSolutions/ViewSolutionsList.cs
+++ b/src/NHSDPublicBrowseAcceptanceTestsSpecflow/Steps/BrowseSolutions/ViewSolutionsList.cs
@@ -35,11 +35,11 @@ namespace NHSDPublicBrowseAcceptanceTestsSpecflow.Steps.BrowseSolutions
             actualNumberOfSolutionCards.Should().Be(expectedNumberOfSolutions);
         }
 
-        [Then(@"the Card contains the Organisation Name")]
-        public void ThenTheCardContainsTheOrganisationName()
+        [Then(@"the Card contains the Supplier Name")]
+        public void ThenTheCardContainsTheSupplierName()
         {
-            var actualNumberOfOrganisationNames = _test.pages.SolutionsList.GetSolutionOrganisationNameCount();
-            actualNumberOfOrganisationNames.Should().Be(expectedNumberOfSolutions);
+            var actualNumberOfSupplierNames = _test.pages.SolutionsList.GetSolutionSupplierNameCount();
+            actualNumberOfSupplierNames.Should().Be(expectedNumberOfSolutions);
         }
 
         [Then(@"the Solution Name")]


### PR DESCRIPTION
changed organisation name to supplier name where necessary, along with locator ids