### PR TITLE
6071: Check document download content type

### DIFF
--- a/src/NHSDPublicBrowseAcceptanceTests.Actions/NHSDPublicBrowseAcceptanceTests.Actions.csproj
+++ b/src/NHSDPublicBrowseAcceptanceTests.Actions/NHSDPublicBrowseAcceptanceTests.Actions.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/CapabilityFilter.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Actions/Pages/CapabilityFilter.cs
@@ -44,7 +44,7 @@ namespace NHSDPublicBrowseAcceptanceTests.Actions.Pages
             var randomCapabilityName = RandomInformation.GetRandomItem(selectedCapabilities);
 
             driver.FindElements(pages.CapabilityFilter.Capabilities)
-                .Single(s => s.FindElement(By.TagName("label")).Text.ToLower().Contains(randomCapabilityName.ToLower()))
+                .First(s => s.FindElement(By.TagName("label")).Text.ToLower().Contains(randomCapabilityName.ToLower()))
                 .FindElement(By.TagName("input")).Click();
 
             return randomCapabilityName;

--- a/src/NHSDPublicBrowseAcceptanceTests.Actions/Utils/DownloadFileUtility.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Actions/Utils/DownloadFileUtility.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using OpenQA.Selenium;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 
@@ -6,14 +8,23 @@ namespace NHSDPublicBrowseAcceptanceTests.Actions.Utils
 {
     public static class DownloadFileUtility
     {
-        public static void DownloadFile(string fileName, string downloadPath, string downloadLink)
+        public static WebClient DownloadFile(string fileName, string downloadPath, string downloadLink, IDictionary<string,string> headers = null)
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
             downloadLink = TransformLocalHost(downloadLink);
             Directory.CreateDirectory(downloadPath);
             using (var client = new WebClient())
             {
+                if(headers != null)
+                {
+                    foreach (var pair in headers)
+                    {
+                        client.Headers.Add(pair.Key, pair.Value);
+                    }
+                }
+
                 client.DownloadFile(downloadLink, Path.Combine(downloadPath, fileName));
+                return client;
             }
         }
 
@@ -28,6 +39,18 @@ namespace NHSDPublicBrowseAcceptanceTests.Actions.Utils
         {
             return new FileInfo(filePath1).Length == new FileInfo(filePath2).Length &&
                    File.ReadAllBytes(filePath1).SequenceEqual(File.ReadAllBytes(filePath2));
+        }
+
+        public static IDictionary<string,string> GetHeadersFromDriver(IWebDriver driver)
+        {
+            var cookies = driver.Manage().Cookies.AllCookies;
+            var useragent = ((IJavaScriptExecutor)driver).ExecuteScript("return navigator.userAgent;");
+            var referer = ((IJavaScriptExecutor)driver).ExecuteScript("return navigator.referer;");
+            IDictionary<string, string> headers = new Dictionary<string, string>();
+            //headers.Add("cookie", (string)cookies.ToDictionary());
+            headers.Add("user-agent", (string)useragent);
+            headers.Add("referer", (string)referer);
+            return new Dictionary<string, string>();
         }
     }
 }

--- a/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/Header.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Objects/Pages/Header.cs
@@ -9,6 +9,6 @@ namespace NHSDPublicBrowseAcceptanceTests.Objects.Pages
 
         public By Container => By.ClassName("nhsuk-header");
 
-        public By TermsBanner => CustomBy.DataTestId("terms-banner");
+        public By TermsBanner => CustomBy.DataTestId("beta-banner");
     }
 }

--- a/src/NHSDPublicBrowseAcceptanceTests.Tests/NHSDPublicBrowseAcceptanceTests.Tests.csproj
+++ b/src/NHSDPublicBrowseAcceptanceTests.Tests/NHSDPublicBrowseAcceptanceTests.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="SpecFlow.NUnit" Version="3.1.82" />
     <PackageReference Include="SpecFlow.NUnit.Runners" Version="3.1.82" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.82" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NHSDPublicBrowseAcceptanceTests.Tests/Steps/BrowseSolutions/CompareSolutions.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Tests/Steps/BrowseSolutions/CompareSolutions.cs
@@ -1,9 +1,12 @@
 ﻿using FluentAssertions;
 using NHSDPublicBrowseAcceptanceTests.Actions.Utils;
 using NHSDPublicBrowseAcceptanceTests.Tests.Utils;
+using OpenQA.Selenium;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using TechTalk.SpecFlow;
 
@@ -40,11 +43,16 @@ namespace NHSDPublicBrowseAcceptanceTests.Tests.Steps.BrowseSolutions
             _test.Pages.SolutionsList.CompareSolutionsButtonIsDisplayed().Should().BeTrue();
             var url = _test.Pages.SolutionsList.GetCompareSolutionsButtonUrl();
             var localFileName = "compare-solutions.xlsx";
-            DownloadFileUtility.DownloadFile(localFileName, _test.DownloadPath, url);
+            //var useragent = ((IJavaScriptExecutor)_test.Driver).ExecuteScript("return navigator.userAgent;");
+            //IDictionary<string, string> headers = new Dictionary<string, string>();
+            //headers.Add("user-agent", (string)useragent);
+
+            IDictionary<string, string> headers = DownloadFileUtility.GetHeadersFromDriver(_test.Driver);
+            var client = DownloadFileUtility.DownloadFile(localFileName, _test.DownloadPath, url, headers);
             var downloadedFile = Path.Combine(_test.DownloadPath, localFileName);
             new FileInfo(downloadedFile).Length.Should().BeGreaterThan(0);
             File.ReadAllBytes(downloadedFile).Length.Should().BeGreaterThan(0);
-            Path.GetExtension(downloadedFile).Should().BeEquivalentTo(".xlsx");
+            client.ResponseHeaders.Get("Content-Type").Should().ContainEquivalentOf("spreadsheetml");
         }
 
         [Then(@"the compare document download button is not displayed")]

--- a/src/NHSDPublicBrowseAcceptanceTests.Tests/Steps/BrowseSolutions/DownloadAttachmentSteps.cs
+++ b/src/NHSDPublicBrowseAcceptanceTests.Tests/Steps/BrowseSolutions/DownloadAttachmentSteps.cs
@@ -75,21 +75,24 @@ namespace NHSDPublicBrowseAcceptanceTestsSpecflow.Steps.BrowseSolutions
         public void WhenTheUserChoosesToDownloadTheAuthorityProvidedDataDocument()
         {
             var url = _test.Pages.ViewASolution.GetAttachmentDownloadLinkUrl();
-            DownloadFileUtility.DownloadFile(providedDataDocumentDownloadFile, _test.DownloadPath, url);
+            var client = DownloadFileUtility.DownloadFile(providedDataDocumentDownloadFile, _test.DownloadPath, url);
+            _context.Add("ResponseHeaderContentType", client.ResponseHeaders.Get("Content-Type"));
         }
 
         [When(@"the User chooses to download the Integrations attachment")]
         public void WhenTheUserChoosesToDownloadTheIntegrationsAttachment()
         {
             var url = _test.Pages.ViewASolution.GetNhsAssuredIntegrationsDownloadLinkUrl();
-            DownloadFileUtility.DownloadFile(integrationsDownloadFile, _test.DownloadPath, url);
+            var client = DownloadFileUtility.DownloadFile(integrationsDownloadFile, _test.DownloadPath, url);
+            _context.Add("ResponseHeaderContentType", client.ResponseHeaders.Get("Content-Type"));
         }
 
         [When(@"the User chooses to download the Roadmap attachment")]
         public void WhenTheUserChoosesToDownloadTheRoadmapAttachment()
         {
             var url = _test.Pages.ViewASolution.GetRoadmapDownloadLinkUrl();
-            DownloadFileUtility.DownloadFile(roadmapDownloadFile, _test.DownloadPath, url);
+            var client = DownloadFileUtility.DownloadFile(roadmapDownloadFile, _test.DownloadPath, url);
+            _context.Add("ResponseHeaderContentType", client.ResponseHeaders.Get("Content-Type"));
         }
 
         [Then(@"the Authority Provided Data Document is downloaded")]
@@ -120,6 +123,8 @@ namespace NHSDPublicBrowseAcceptanceTestsSpecflow.Steps.BrowseSolutions
                 "SampleData", "authority provided solution document.pdf");
             var downloadedFile = Path.Combine(_test.DownloadPath, providedDataDocumentDownloadFile);
             DownloadFileUtility.CompareTwoFiles(downloadedFile, sourceFile).Should().BeTrue();
+            var ResponseHeaderContentType = (string)_context["ResponseHeaderContentType"];
+            ResponseHeaderContentType.Should().ContainEquivalentOf("pdf");
         }
 
         [Then(@"the attachment contains the Supplier's NHS Assured Integrations")]
@@ -129,6 +134,8 @@ namespace NHSDPublicBrowseAcceptanceTestsSpecflow.Steps.BrowseSolutions
                 "SampleData", "integrations.pdf");
             var downloadedFile = Path.Combine(_test.DownloadPath, integrationsDownloadFile);
             DownloadFileUtility.CompareTwoFiles(downloadedFile, sourceFile).Should().BeTrue();
+            var ResponseHeaderContentType = (string)_context["ResponseHeaderContentType"];
+            ResponseHeaderContentType.Should().ContainEquivalentOf("pdf");
         }
 
         [Then(@"the attachment contains the Supplier's Roadmap")]
@@ -138,6 +145,8 @@ namespace NHSDPublicBrowseAcceptanceTestsSpecflow.Steps.BrowseSolutions
                 "SampleData", "roadmap.pdf");
             var downloadedFile = Path.Combine(_test.DownloadPath, roadmapDownloadFile);
             DownloadFileUtility.CompareTwoFiles(downloadedFile, sourceFile).Should().BeTrue();
+            var ResponseHeaderContentType = (string)_context["ResponseHeaderContentType"];
+            ResponseHeaderContentType.Should().ContainEquivalentOf("pdf");
         }
 
         [Then(@"there is no call to action to download a file in the Integrations section")]


### PR DESCRIPTION
added user agent to http requests, added check on document response content type header, fixed terms banner locator
[AB#6071](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/6071)